### PR TITLE
Apply status bar tint to Lollipop

### DIFF
--- a/org.fox.ttrss/src/main/java/org/fox/ttrss/CommonActivity.java
+++ b/org.fox.ttrss/src/main/java/org/fox/ttrss/CommonActivity.java
@@ -165,7 +165,7 @@ public class CommonActivity extends ActionBarActivity {
 	}
 
 	public void setStatusBarTint() {
-		if (android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.KITKAT &&
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT &&
                 !m_prefs.getBoolean("full_screen_mode", false)) {
 
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS,


### PR DESCRIPTION
Status bar tint is currently fixed for Kitkat. Lollipop needs some love too.